### PR TITLE
users: fix lastEditedBy and sinceLastEdit logic for virgin Wiki

### DIFF
--- a/client/views/page_index/page_index.coffee
+++ b/client/views/page_index/page_index.coffee
@@ -78,6 +78,8 @@ buildLinks = (context, tree, rootNode) ->
 Template.pageindex.test = ->
     tree = new Tree
     entry = Entries.findOne({_id: 'home'})
+    if ! entry?
+        return "No Wiki Pages Exist. You should make one!"
     tree.root = new Node "/"+entry.title,entry.title, null
     tree.nameArray.push entry.title
 

--- a/lib/users.coffee
+++ b/lib/users.coffee
@@ -54,7 +54,7 @@ root.timeSinceLast = (user, collection) ->
 	Math.abs Math.floor((now - last.createdAt) / 1000)
 
 root.lastEditedBy = (entry) ->
-	if entry._id
+	if entry? and entry._id
 		lastRev = Revisions.findOne({entryId: entry._id},{sort:{ date : -1}})
 	else
 		return
@@ -66,7 +66,7 @@ root.lastEditedBy = (entry) ->
 	author.username
 
 root.sinceLastEdit = (entry) ->
-	if entry._id
+	if entry? and entry._id
 		lastRev = Revisions.findOne({entryId: entry._id},{sort:{ date : -1}})
 	else
 		return


### PR DESCRIPTION
@funkyeah, This fixes the issue I was running into getting the dev branch to work in a new environment.  The other change was removing the symlink for spin from the packages directory and cloning the latest version (not published to atmoshphere).

The second bit in the ternary expression is likely not required as you noted.  Any existing entry should have an assocaited `_id`.
